### PR TITLE
Fixes themedir error in Sphinx 8.2.0

### DIFF
--- a/ntd2d/ntd2d_action/sphinxdocs.py
+++ b/ntd2d/ntd2d_action/sphinxdocs.py
@@ -3,6 +3,7 @@
 """
 __docformat__ = 'restructuredtext'
 
+import importlib
 import github_action_utils as gha_utils
 import os
 import pathlib
@@ -162,13 +163,13 @@ class BorgedSphinxDocs(SphinxDocs):
         https://github.com/sphinx-doc/sphinx/issues/12049
         """
         def get_theme_layout(theme):
-            if hasattr(theme, "themedir"):
-                if (pathlib.Path(theme.themedir) / "layout.html").exists():
-                    return f"{theme.name}/layout.html"
-                else:
-                    return get_theme_layout(theme.base)
-            else:
+            if hasattr(theme, "themedir") and (pathlib.Path(theme.themedir) / "layout.html").exists():
+                return f"{theme.name}/layout.html"
+            elif hasattr(theme, "base"):
                 return get_theme_layout(theme.base)
+            else:
+                with importlib.resources.path(theme.name, "") as path:
+                    return f"{path}/layout.html"
 
         return get_theme_layout(self.get_theme(self.inherited_theme))
 

--- a/ntd2d/ntd2d_action/sphinxdocs.py
+++ b/ntd2d/ntd2d_action/sphinxdocs.py
@@ -4,7 +4,6 @@
 __docformat__ = 'restructuredtext'
 
 import github_action_utils as gha_utils
-import importlib
 import os
 import pathlib
 import shlex
@@ -12,9 +11,7 @@ import shutil
 from sphinx.application import Sphinx
 from sphinx.theming import HTMLThemeFactory
 import subprocess
-import sys
 import tempfile
-import traceback
 
 from .files import ConfFile
 from .files import SphinxLog, BorgedConfFile, TemplateHierarchy
@@ -165,38 +162,13 @@ class BorgedSphinxDocs(SphinxDocs):
         https://github.com/sphinx-doc/sphinx/issues/12049
         """
         def get_theme_layout(theme):
-            # Handle both old and new Sphinx theme implementations
-            theme_dir = None
-            
-            # Try different ways to get the theme directory
-            if hasattr(theme, 'themedir'):
-                theme_dir = theme.themedir
-            elif hasattr(theme, '_template_dir'):
-                theme_dir = theme._template_dir
-            elif hasattr(theme, 'get_theme_dir'):
-                theme_dir = theme.get_theme_dir()
-            elif hasattr(theme, 'dirs'):
-                # Some themes store their files in a 'dirs' list
-                theme_dir = theme.dirs[0] if theme.dirs else None
-                
-            if theme_dir is None:
-                # If we can't find the theme directory, try to get it from the module
-                try:
-                    theme_module = __import__(theme.name.replace("-", "_"), fromlist=[''])
-                    theme_dir = os.path.dirname(os.path.abspath(theme_module.__file__))
-                except ImportError:
-                    # If all else fails, try to construct a path from the theme name
-                    theme_dir = os.path.join(self.conf.theme_path, theme.name)
-
-            layout_path = pathlib.Path(theme_dir) / "layout.html"
-            
-            if layout_path.exists():
-                return f"{theme.name}/layout.html"
-            elif hasattr(theme, 'base') and theme.base is not None:
-                return get_theme_layout(theme.base)
+            if hasattr(theme, "themedir"):
+                if (pathlib.Path(theme.themedir) / "layout.html").exists():
+                    return f"{theme.name}/layout.html"
+                else:
+                    return get_theme_layout(theme.base)
             else:
-                # If we can't find a layout, return a basic one
-                return "basic/layout.html"
+                return get_theme_layout(theme.base)
 
         return get_theme_layout(self.get_theme(self.inherited_theme))
 


### PR DESCRIPTION
Sphinx 8 doesn't expose the "themedir" attribute anymore so the get_theme_layout method was failing on an AttributeError. This is fixed by simply adding a hasattr guard around that variable access. 

I've tested this with Sphinx v8.2.0 and it seems to build now. 